### PR TITLE
Added ability to click on the commenter name to access user page

### DIFF
--- a/views/showpost.ejs
+++ b/views/showpost.ejs
@@ -16,7 +16,7 @@
 		<% post.comments.forEach(function(comment){ %>
 			<div class="row">
 				<div class="col">
-					<p class="text-left pl-4"><strong><%= comment.author.username %></strong><br><%= comment.text %></p>
+					<p class="text-left pl-4"><a style="color: white" href="/user/<%= comment.author.username %>"><strong><%= comment.author.username %></strong></a><br><%= comment.text %></p>
 				</div>
 				<div class="col text-right mr-5">
 					<p class="mb-0"><em><%= moment(comment.created).fromNow() %></em></p>


### PR DESCRIPTION
Well, pretty much self explanatory, clicking on the name of the commenter on a comment sends to the commenter's user page.